### PR TITLE
Fix DeepSeek thinkMode and API custom pricing persistence

### DIFF
--- a/www/script.js
+++ b/www/script.js
@@ -966,6 +966,7 @@ async function loadContactsForList() {
             personality: contact.personality,
             customPrompts: contact.customPrompts,
             voiceId: contact.voiceId,
+            thinkMode: contact.thinkMode || 'default',
             bubbleStyleId: contact.bubbleStyleId,
             members: contact.members,
             memoryTableContent: contact.memoryTableContent,
@@ -1070,6 +1071,7 @@ async function loadContactsForList() {
             personality: contact.personality,
             customPrompts: contact.customPrompts,
             voiceId: contact.voiceId,
+            thinkMode: contact.thinkMode || 'default',
             bubbleStyleId: contact.bubbleStyleId,
             members: contact.members,
             memoryTableContent: contact.memoryTableContent
@@ -3998,6 +4000,14 @@ function bindApiCheckButton() {
     document.getElementById('minimaxGroupId').value = apiSettings.minimaxGroupId;
     document.getElementById('minimaxApiKey').value = apiSettings.minimaxApiKey;
     document.getElementById('glmApiKey').value = apiSettings.glmApiKey || '';
+
+    // 计费标准回显（元/百万Token）
+    const priceHitEl = document.getElementById('priceHit');
+    const priceMissEl = document.getElementById('priceMiss');
+    const priceOutEl = document.getElementById('priceOut');
+    if (priceHitEl) priceHitEl.value = apiSettings.priceHit ?? 1.0;
+    if (priceMissEl) priceMissEl.value = apiSettings.priceMiss ?? 12.0;
+    if (priceOutEl) priceOutEl.value = apiSettings.priceOut ?? 24.0;
 
     const primarySelect = document.getElementById('primaryModelSelect');
     const secondarySelect = document.getElementById('secondaryModelSelect');


### PR DESCRIPTION
### Motivation
- Contacts loaded for the list were stripped of the `thinkMode` field, which caused DeepSeek thinking mode selections to revert to `default` after reopening or editing a contact.
- The API settings modal initialization path used by the `bindApiCheckButton()` flow did not repopulate custom pricing inputs, so saved pricing could be unintentionally overwritten by defaults.

### Description
- Restore `thinkMode` when creating lightweight contact summaries in `loadContactsForList()` so contact edits preserve previously selected DeepSeek modes by including `thinkMode: contact.thinkMode || 'default'`.
- Populate API pricing input fields (`priceHit`, `priceMiss`, `priceOut`) inside `bindApiCheckButton()` using `apiSettings` so reopening the API modal rehydrates the saved values.
- Minor UI/flow-safe defaults are retained (`|| 'default'` and `??` fallbacks) so missing values still behave predictably.

### Testing
- Ran a syntax check with `node --check www/script.js` which completed successfully.
- Reviewed the affected code paths for contact loading/editing and API settings open/save flows to ensure the fields are loaded and preserved during save operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e6f2cd64833390a88f1153da67e5)